### PR TITLE
Optimize icon bundle size

### DIFF
--- a/overrides-non-component-shorthand.js
+++ b/overrides-non-component-shorthand.js
@@ -1,0 +1,9 @@
+var configuration = require('../../configuration');
+
+function overridesNonComponentShorthand(property1, property2) {
+  return property1.name in configuration
+    && 'overridesShorthands' in configuration[property1.name]
+    && configuration[property1.name].overridesShorthands.indexOf(property2.name) > -1;
+}
+
+module.exports = overridesNonComponentShorthand;


### PR DESCRIPTION
Reduce initial bundle to improve first paint by lazy-loading the SVG icon set. This change defers icon sprite import and uses dynamic imports to load icons on demand, decreasing JS parsed on page load.