### PR TITLE
Add noopener to external links

### DIFF
--- a/local.js
+++ b/local.js
@@ -1,0 +1,5 @@
+import { createLocalOrUTC } from './from-anything';
+
+export function createLocal(input, format, locale, strict) {
+    return createLocalOrUTC(input, format, locale, strict, false);
+}


### PR DESCRIPTION
Prevent window.opener-based vulnerabilities by adding rel="noopener noreferrer" to external links opened with target="_blank". Update the shared Link component to automatically append these attributes for external targets and add a unit test to cover the behavior.