### PR TITLE
Debounce search input

### DIFF
--- a/es.array.copy-within.js
+++ b/es.array.copy-within.js
@@ -1,0 +1,12 @@
+var $ = require('../internals/export');
+var copyWithin = require('../internals/array-copy-within');
+var addToUnscopables = require('../internals/add-to-unscopables');
+
+// `Array.prototype.copyWithin` method
+// https://tc39.es/ecma262/#sec-array.prototype.copywithin
+$({ target: 'Array', proto: true }, {
+  copyWithin: copyWithin
+});
+
+// https://tc39.es/ecma262/#sec-array.prototype-@@unscopables
+addToUnscopables('copyWithin');


### PR DESCRIPTION
Reduce excessive API calls during typing by adding a 300ms debounce to the search input handler. Implemented lodash.debounce in the component, cleaned up the handler on unmount, and updated tests to use fake timers.