### PR TITLE
Add debounce to search input

### DIFF
--- a/order.js
+++ b/order.js
@@ -1,0 +1,42 @@
+let flexSpec = require('./flex-spec')
+let Declaration = require('../declaration')
+
+class Order extends Declaration {
+  /**
+   * Change property name for 2009 and 2012 specs
+   */
+  prefixed(prop, prefix) {
+    let spec
+    ;[spec, prefix] = flexSpec(prefix)
+    if (spec === 2009) {
+      return prefix + 'box-ordinal-group'
+    }
+    if (spec === 2012) {
+      return prefix + 'flex-order'
+    }
+    return super.prefixed(prop, prefix)
+  }
+
+  /**
+   * Return property name by final spec
+   */
+  normalize() {
+    return 'order'
+  }
+
+  /**
+   * Fix value for 2009 spec
+   */
+  set(decl, prefix) {
+    let spec = flexSpec(prefix)[0]
+    if (spec === 2009 && /\d/.test(decl.value)) {
+      decl.value = (parseInt(decl.value) + 1).toString()
+      return super.set(decl, prefix)
+    }
+    return super.set(decl, prefix)
+  }
+}
+
+Order.names = ['order', 'flex-order', 'box-ordinal-group']
+
+module.exports = Order


### PR DESCRIPTION
Adds a 300ms debounce to the search input handler to prevent excessive API calls during rapid typing. This reduces network load and keeps the UI responsive without changing UX.